### PR TITLE
Feature/14 startup script that generates ssl certificates and runs the dotnet watch command

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -6,16 +6,17 @@ This document describes the use of the compose files and the dependencies that n
 
 Dependencies:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-- [OpenSSL](https://www.openssl.org/source/)
 
 ## Setup
-Generate SSL certificates so `nginx` can consume them:
-```bash
-# cwd nginx
-chmod +x ./certificates.sh && ./certificates.sh
-```
 
-## Running the containers
+### Nginx
+The Nginx Dockerfile is located in `./nginx/Dockerfile.debug` it is now a standalone Dockerfile which is modified to generate SSL certificates on the startup removing the need for the developer to do it manualy.
+
+It runs the `./nginx/startup.sh` script which generates the certificates for localhost and after that it runs nginx.
+
+The certificates are mapped to the volume and are located inside `./nginx/certs` && `./nginx/keys` so you can inspect them, they are also ignored from tracking.
+
+### Running the containers
 To mimic a deployment environment we added support for docker compose and debugging on it, simply we are running `dotnet watch run` inside our container so that every change gets replicated in the container. 
 
 To use this functionality just run the following command:

--- a/compose/docker-compose.debug.arm.yml
+++ b/compose/docker-compose.debug.arm.yml
@@ -13,13 +13,20 @@ services:
     restart: unless-stopped
     volumes:
       - sqlserver_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "6ha9hqOpaJI430J*JVr*", "-Q", "SELECT 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
 
   mssql-tools:
     container_name: tools
     image: mcr.microsoft.com/mssql-tools:latest
     user: root
     depends_on:
-      - mssql
+      mssql:
+        condition: service_started
     environment:
       MSSQL_SA_PASSWORD: 6ha9hqOpaJI430J*JVr*
       MSSQL_HOST: mssql
@@ -57,6 +64,13 @@ services:
       - /app/src/Template.Infrastructure/bin/
       - /app/src/Template.Application/obj/
       - /app/src/Template.Application/bin/
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
 
   nginx:
     build:
@@ -68,7 +82,8 @@ services:
       - 443:443
     command: sh -c "/usr/local/bin/startup.sh"
     depends_on:
-      - api
+      api:
+        condition: service_started
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/certs/:/etc/ssl/certs/

--- a/compose/docker-compose.debug.arm.yml
+++ b/compose/docker-compose.debug.arm.yml
@@ -43,17 +43,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
     expose:
       - 5000
-    command: [
-      "dotnet", 
-      "watch", 
-      "run", 
-      -v,
-      "--project", 
-      "/app/src/Template.Api/Template.Api.csproj", 
-      "--urls", 
-      "http://*:5000",
-      "--non-interactive"
-      ]
+    command: sh -c "./compose/startup.sh"
     depends_on:
       mssql-tools:
         condition: service_completed_successfully
@@ -69,11 +59,14 @@ services:
       - /app/src/Template.Application/bin/
 
   nginx:
-    image: nginx:latest
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile.debug
     container_name: nginx
     ports:
       - 80:80
       - 443:443
+    command: sh -c "/usr/local/bin/startup.sh"
     depends_on:
       - api
     volumes:

--- a/compose/nginx/Dockerfile.debug
+++ b/compose/nginx/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM nginx:latest as build 
+FROM nginx:latest
 
 WORKDIR /usr/local/bin
 

--- a/compose/nginx/Dockerfile.debug
+++ b/compose/nginx/Dockerfile.debug
@@ -1,0 +1,9 @@
+FROM nginx:latest as build 
+
+WORKDIR /usr/local/bin
+
+COPY ./startup.sh .
+
+RUN chmod +x ./startup.sh
+
+CMD [ "/usr/local/bin/startup.sh" ]

--- a/compose/nginx/startup.sh
+++ b/compose/nginx/startup.sh
@@ -5,11 +5,13 @@ mkdir -p certs
 
 openssl genpkey \
     -algorithm RSA \
-    -out keys/localhost.key
+    -out /etc/ssl/private/localhost.key
 
 openssl req \
-    -new -x509 -key keys/localhost.key \
-    -out certs/localhost.crt \
+    -new -x509 -key /etc/ssl/private/localhost.key \
+    -out /etc/ssl/certs/localhost.crt \
     -days 365 \
     -subj "/CN=localhost" \
     -addext "subjectAltName=DNS:localhost"
+
+exec nginx -g 'daemon off;'

--- a/compose/startup.sh
+++ b/compose/startup.sh
@@ -1,0 +1,5 @@
+dotnet watch run \
+    -v \
+    --project /app/src/Template.Api/Template.Api.csproj \
+    --urls "http://*:5000" \
+    --non-interactive


### PR DESCRIPTION
- Starting .NET  has been moved to `./compose/startup.sh`
- The nginx service is beeing built with the `./compose/nginx/Dockerfile.debug` and it is generateing SSL certificates on startup from the `./compose/nginx/startup.sh` 
- Services in compose now have healthecks and dependencies between each other