### PR TITLE
Volume for nuget packages

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -43,7 +43,16 @@ And to make it convinient run:
 docker-compose -f ./docker-compose.debug.arm.yml down && docker-compose -f ./docker-compose.debug.arm.yml up --build
 
 # x86 based CPU's (intel, amd)
-docker-compose -f ./docker-compose.debug.amd.yml down && docker-compose -f ./docker-compose.debug.amd.yml up --build
+docker-compose -f ./docker-compose.debug.amd.yml down; docker-compose -f ./docker-compose.debug.amd.yml up --build
+```
+
+### Formatting .sh files
+```bash
+vi -b filename
+
+:%s/\r$//
+:x
+
 ```
 
 ## Improvements

--- a/compose/docker-compose.debug.amd.yml
+++ b/compose/docker-compose.debug.amd.yml
@@ -56,6 +56,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ../:/app
+      - ~/.nuget/packages:/root/.nuget/packages:ro
       - /app/src/Template.Api/obj/
       - /app/src/Template.Api/bin/
       - /app/src/Template.Domain/obj/

--- a/compose/docker-compose.debug.arm.yml
+++ b/compose/docker-compose.debug.arm.yml
@@ -56,6 +56,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ../:/app
+      - ~/.nuget/packages:/root/.nuget/packages:ro
       - /app/src/Template.Api/obj/
       - /app/src/Template.Api/bin/
       - /app/src/Template.Domain/obj/

--- a/src/Template.Api/Dockerfile.debug
+++ b/src/Template.Api/Dockerfile.debug
@@ -3,5 +3,3 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 COPY . .
-
-RUN dotnet restore

--- a/src/Template.Api/Program.cs
+++ b/src/Template.Api/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder
     .Configuration.SetBasePath(builder.Environment.ContentRootPath)
-    .AddJsonFile($"appsettings.Internal.json", optional: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
     .AddEnvironmentVariables();
 
 builder.Services.AddApi().AddInfrastructure(builder.Configuration).AddApplication();


### PR DESCRIPTION
- Nuget packages volume, more efficient compose, nuget packages dont need to be installed inside the container, they will be monted from the host into the container.

- [x] Need's to be tested on a windows machine before merge, so we can adjust the `~/` path if needed